### PR TITLE
Fix help causing errors for commands with no arguments

### DIFF
--- a/src/bot/libraries/documentation.ts
+++ b/src/bot/libraries/documentation.ts
@@ -61,21 +61,25 @@ export class Documentation {
      * Returns a string with the full detailed help information for a command.
      */
     public static getCommandHelp(command: Command) : RichEmbed {
+        let fields = [{
+            name: 'Usage',
+            value: '`' + this.getInlineUsage(command) + '`'
+        }];
+
+        // If there are arguments, add it to the fields
+        if (command.getArguments().length > 0) {
+            fields.push({
+                name: 'Arguments',
+                value: Documentation.getArgumentDetails(command)
+            });
+        }
+
         // Build the embed
         let embed = new RichEmbed({
             description: command.getDescription() + '\n',
             color: 0x1c7ed6,
             author: { name: 'Help for ' + command.getName() },
-            fields: [
-                {
-                    name: 'Usage',
-                    value: '`' + this.getInlineUsage(command) + '`'
-                },
-                {
-                    name: 'Arguments',
-                    value: Documentation.getArgumentDetails(command)
-                }
-            ]
+            fields: fields
         });
 
         return embed;


### PR DESCRIPTION
Help information for commands was hardcoded to always include the arguments section. When a command had no arguments, it was blank and resulted in an API error.