### PR TITLE
Reload commands without restarting the bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -335,9 +335,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+      "version": "11.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.7.tgz",
+      "integrity": "sha512-bHbRcyD6XpXVLg42QYaQCjvDXaCFkvb3WbCIxSDmhGbJYVroxvYzekk9QGg1beeIawfvSLkdZpP0h7jxE4ihnA=="
     },
     "@types/request": {
       "version": "2.48.1",
@@ -2682,6 +2682,11 @@
         "tar": "^4"
       }
     },
+    "node-watch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.0.tgz",
+      "integrity": "sha512-XAgTL05z75ptd7JSVejH1a2Dm1zmXYhuDr9l230Qk6Z7/7GPcnAs/UyJJ4ggsXSvWil8iOzwQLW0zuGUvHpG8g=="
+    },
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
@@ -4011,9 +4016,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "3.3.4000",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "lodash": "^4.17.11",
         "moment": "^2.24.0",
         "node-opus": "^0.3.1",
+        "node-watch": "^0.6.0",
         "queue": "^5.0.1",
         "random-number-csprng": "^1.0.2",
         "request": "^2.88.0",
@@ -37,7 +38,7 @@
         "@types/cheerio": "^0.22.11",
         "@types/lodash": "^4.14.123",
         "@types/mocha": "^5.2.6",
-        "@types/node": "^11.11.3",
+        "@types/node": "^11.11.7",
         "@types/request": "^2.48.1",
         "@types/socket.io": "^2.1.2",
         "@types/sqlite3": "^3.1.5",
@@ -45,6 +46,6 @@
         "mocha": "^6.0.2",
         "source-map-support": "^0.5.11",
         "ts-node": "^8.0.3",
-        "typescript": "^3.3.3333"
+        "typescript": "^3.3.4000"
     }
 }

--- a/src/framework/framework.ts
+++ b/src/framework/framework.ts
@@ -18,13 +18,16 @@ import { Database } from './lib/database';
 
 import chalk from 'chalk';
 import { Documentation } from '@bot/libraries/documentation';
+import { Filesystem } from './internal/filesystem';
 
 export class Framework {
     private static config: BotConfiguration;
     private static client: Client;
     private static logger: Logger;
-    private static commands: Command[] = [];
     private static server?: Server;
+
+    private static commands: { instance: Command, filePath: string, className: string }[] = [];
+    private static listeners: { instance: Listener, filePath: string, className: string }[] = [];
 
     /**
      * Starts the bot.
@@ -59,6 +62,9 @@ export class Framework {
                 this.listen();
 
                 this.logger.info('Bot is online...');
+
+                // Start watching files for changes
+                Filesystem.watch();
             });
         }
         else {
@@ -250,7 +256,7 @@ export class Framework {
                             let instance = new command();
 
                             if (instance instanceof Command) {
-                                this.commands.push(instance);
+                                this.commands.push({ instance, filePath, className });
                             }
                         }
                     }
@@ -288,6 +294,7 @@ export class Framework {
                             let instance = new listener();
 
                             if (instance instanceof Listener) {
+                                this.listeners.push({ instance, filePath, className });
                                 instance.start();
                             }
                         }
@@ -493,8 +500,8 @@ export class Framework {
         for (let i = 0; i < this.commands.length; i++) {
             let command = this.commands[i];
 
-            if (command.hasAlias(name)) {
-                return command;
+            if (command.instance.hasAlias(name)) {
+                return command.instance;
             }
         }
 
@@ -505,7 +512,73 @@ export class Framework {
      * Returns all running commands in the framework.
      */
     public static getCommands() : Command[] {
-        return this.commands;
+        let commands : Command[] = [];
+
+        this.commands.forEach(entry => {
+            commands.push(entry.instance);
+        });
+
+        return commands;
+    }
+
+    /**
+     * Returns all running listeners in the framework.
+     */
+    public static getListeners() : Listener[] {
+        let listeners : Listener[] = [];
+
+        this.listeners.forEach(entry => {
+            listeners.push(entry.instance);
+        });
+
+        return listeners;
+    }
+
+    /**
+     * Reloads all commands and listeners from the disk. This does not clear cache automatically, so unless you do that,
+     * it will reload the same cached code as before.
+     */
+    public static reload() {
+        this.commands.forEach(command => {
+            this.reloadEntry(command);
+        });
+
+        this.listeners.forEach(listener => {
+            listener.instance.stop();
+            this.reloadEntry(listener);
+        });
+    }
+
+    /**
+     * Reloads a given command or listener entry.
+     */
+    private static reloadEntry(entry: any) {
+        let type = (entry instanceof Command) ? 'command' : 'listener';
+
+        // Warn if the command file no longer exists
+        if (!fs.existsSync(entry.filePath)) {
+            this.getLogger().warning(`Cannot reload ${type} "${entry.className}" because its file was deleted: ${entry.filePath}`);
+            return;
+        }
+
+        try {
+            // Require the new file and get its export
+            let exported = require(entry.filePath);
+            let object = exported[entry.className];
+
+            // Warn if the export has gone missing
+            if (!object) {
+                this.getLogger().warning(`Cannot reload ${type} "${entry.className}" because its file no longer exports that class: ${entry.filePath}`);
+                return;
+            }
+
+            // Set the new instance
+            entry.instance = new object();
+        }
+        catch (e) {
+            this.getLogger().warning(`Encountered an error when reloading ${type} "${entry.className}"`);
+            this.getLogger().warning(e);
+        }
     }
 }
 

--- a/src/framework/framework.ts
+++ b/src/framework/framework.ts
@@ -64,7 +64,7 @@ export class Framework {
                 this.logger.info('Bot is online...');
 
                 // Start watching files for changes
-                Filesystem.watch();
+                if (this.getEnvironment() == 'test') Filesystem.watch();
             });
         }
         else {

--- a/src/framework/internal/filesystem.ts
+++ b/src/framework/internal/filesystem.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Framework } from '@core/framework';
+
+const watch = require('node-watch') as WatchFunction;
+
+export class Filesystem {
+    private static watching: string[] = [];
+    private static buffer: string[] = [];
+    private static timeout: NodeJS.Timeout | undefined;
+
+    /**
+     * Watches the filesystem for changes to modules which operate the bot.
+     */
+    public static watch() {
+        this.watchDirectory(path.join(__dirname, '../../bot/'));
+        this.watchDirectory(path.join(__dirname, '../bot/'));
+        this.watchDirectory(path.join(__dirname, '../lib/'));
+    }
+
+    /**
+     * Watches a specific directory for changes.
+     */
+    private static watchDirectory(dir: string) {
+        this.watching.push(dir);
+
+        let scriptsDir = path.join(__dirname, '../../bot/scripts');
+
+        let filter = (name: string) => !name.endsWith('.map');
+        let persistent = true;
+        let recursive = true;
+
+        watch(dir, { persistent, recursive, filter }, (type, fileName) => {
+            if (type == 'update') {
+                // Clear cache
+                this.clearModuleCache();
+
+                // If the file is a script, require it
+                if (fileName.startsWith(scriptsDir)) {
+                    try {
+                        require(fileName);
+                    }
+                    catch (e) {
+                        Framework.getLogger().error(e);
+                    }
+                }
+
+                // Add it to the buffer
+                this.buffer.push(fileName);
+
+                // Set a new timeout
+                if (this.timeout) clearTimeout(this.timeout);
+                this.timeout = setTimeout(() => { this.executeBuffer() }, 300);
+            }
+        });
+    }
+
+    /**
+     * Executes the internal buffer, which reloads commands and listeners in the bot.
+     */
+    private static executeBuffer() {
+        // Reset the buffer
+        let files = this.buffer;
+        this.buffer = [];
+
+        // Reload commands and listeners
+        let start = _.now();
+        Framework.reload();
+
+        // Log file count
+        let time = _.now() - start;
+        Framework.getLogger().info(`Reloaded ${files.length} file${files.length != 1 ? 's' : ''} in ${time.toFixed(0)} millis.`);
+    }
+
+    /**
+     * Clears cached modules from `require()` so they may be imported again from disk.
+     */
+    private static clearModuleCache() {
+        Object.keys(require.cache).forEach(key => {
+            this.watching.forEach(dirPath => {
+                if (key.startsWith(dirPath)) {
+                    delete require.cache[key];
+                }
+            });
+        });
+    }
+}
+
+type WatchFunction = ((fileName: string, options: WatchOptions, listener: (type: 'update' | 'remove', fileName: string) => any) => fs.FSWatcher);
+type WatchOptions = {
+    delay ?: number;
+    encoding ?: string;
+    filter ?: RegExp | ((fileName: string) => boolean);
+    persistent ?: boolean;
+    recursive ?: boolean;
+};


### PR DESCRIPTION
This pull request adds a filesystem watcher, which keeps an eye on files that affect the bot's operations (listeners, libraries, and commands). When these files are modified on the disk, the require cache will be wiped, and all commands, libraries, and listeners are reloaded seamlessly.

Still experimental.