### PR TITLE
Improve help

### DIFF
--- a/src/bot/libraries/documentation.ts
+++ b/src/bot/libraries/documentation.ts
@@ -26,9 +26,13 @@ export class Documentation {
             result += `•  \`${arg.getName()}\`` + (arg.getDescription() ? `  –  ${arg.getDescription()}` : '');
             result += '\n';
 
-            if (options && options.length > 1) {
+            if (options && options.length > 1 && options.length <= 6) {
                 options.forEach((option : any) => {
-                    result += `    ‣  \`${option}\`\n`;
+                    let segment = `    ‣  \`${option}\`\n`;
+
+                    if (result.length + segment.length <= 1024) {
+                        result += segment;
+                    }
                 });
             }
         });

--- a/src/framework/internal/argument.ts
+++ b/src/framework/internal/argument.ts
@@ -129,7 +129,7 @@ export class Argument {
         else if (_.isEqual(this.getConstraints(), ['mention'])) components.push('@' + this.getName());
         else components.push(this.getName());
 
-        if (this.getDefaultValue() != undefined) {
+        if (this.getDefaultValue() != undefined && this.getDefaultValue() != '') {
             let d = '' + this.getDefaultValue();
             if (d == '@mention' || d == '@member') d = 'you';
             components.push(' = ' + d);


### PR DESCRIPTION
This pull request will:

- Remove long argument lists from usage information. This will encourage us to be more concise in the future, and protect against the 1024 character limit for an embedded field.

- Omit the default value for blank strings in help usage (e.g. `dog [breed = ]` becomes `dog [breed]`).