### PR TITLE
Add automatic database migrations

### DIFF
--- a/src/framework/framework.ts
+++ b/src/framework/framework.ts
@@ -233,6 +233,21 @@ export class Framework {
                 this.logger.info(`Database migrated to version v${version} successfully.`);
             }
         }
+
+        // Run migrations
+        let migrationFiles = Database.getMigrationFiles();
+        for (let i = 0; i < migrationFiles.length; i++) {
+            let file = migrationFiles[i];
+            this.logger.info(`Migrating database to v${file.version}...`);
+
+            let queries = fs.readFileSync(file.path).toString();
+            await Database.run(queries);
+        }
+
+        // Update the version if we ran migrations
+        if (migrationFiles.length > 0) {
+            version = await Database.getSchemaVersion();
+        }
     }
 
     /**


### PR DESCRIPTION
By adding sql files to the `public/migrations/` directory, with the name of the file set to the database version in the format of `x.x.x.sql`, the framework will automatically detect the newer version and run the queries in the sql file. 

The sql file is expected to run the necessary query to bring up the database version:

```sql
UPDATE `meta` SET `value` = 'x.x.x' WHERE `name` = 'version';
```